### PR TITLE
Add pick and drop weapon sounds

### DIFF
--- a/Assets/Prefabs/AK74.prefab
+++ b/Assets/Prefabs/AK74.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 8624699325493113409}
   - component: {fileID: 8624699325493113410}
   - component: {fileID: 8624699325493113411}
+  - component: {fileID: 505898869348145410}
   m_Layer: 11
   m_Name: AK74
   m_TagString: FireWeapon
@@ -131,8 +132,33 @@ MonoBehaviour:
   muzzleFlash: {fileID: 6012287433735400708}
   impactEffect: {fileID: 1000010844420130, guid: 4edabb1c0dde62743b137378c7d22980,
     type: 3}
-  inUse: 1
+  dropEmitter: {fileID: 505898869348145410}
+  inUse: 0
   isEquipped: 0
+  dropSoundInterval: 0.5
+--- !u!114 &505898869348145410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8624699325493113412}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a6610d2e704f1648819acc8d7460285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CollisionTag: 
+  Event: event:/Johannes/WeaponDrop
+  PlayEvent: 0
+  StopEvent: 0
+  AllowFadeout: 1
+  TriggerOnce: 0
+  Preload: 0
+  Params: []
+  OverrideAttenuation: 0
+  OverrideMinDistance: 1
+  OverrideMaxDistance: 20
 --- !u!1 &8624699325819655060
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/M1911.prefab
+++ b/Assets/Prefabs/M1911.prefab
@@ -201,11 +201,12 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5406812856881708614}
+  - component: {fileID: 5320465351508668338}
+  - component: {fileID: 2453873835470347257}
   - component: {fileID: 5406812856881833152}
   - component: {fileID: 5406812856881833215}
   - component: {fileID: 7657981801554065792}
-  - component: {fileID: 5320465351508668338}
-  - component: {fileID: 2453873835470347257}
+  - component: {fileID: 1577568351210669546}
   m_Layer: 11
   m_Name: M1911
   m_TagString: FireWeapon
@@ -230,53 +231,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &5406812856881833152
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406812856881865318}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.089749455, y: 0.19803512, z: 0.3128357}
-  m_Center: {x: -0.0070440024, y: -0.04115647, z: -0.03291162}
---- !u!54 &5406812856881833215
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406812856881865318}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 1
-  m_Interpolate: 2
-  m_Constraints: 0
-  m_CollisionDetection: 3
---- !u!114 &7657981801554065792
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5406812856881865318}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a167ae81725a9c144af7d71a546ad7b6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _fireRate: 0
-  muzzleFlash: {fileID: 386750249455059553}
-  impactEffect: {fileID: 1000010355441670, guid: 02a509a7fa70ed740ba4197e20c5d32d,
-    type: 3}
-  inUse: 0
-  isEquipped: 0
 --- !u!33 &5320465351508668338
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -324,6 +278,77 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!65 &5406812856881833152
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5406812856881865318}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.089749455, y: 0.19803512, z: 0.3128357}
+  m_Center: {x: -0.0070440024, y: -0.04115647, z: -0.03291162}
+--- !u!54 &5406812856881833215
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5406812856881865318}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 2
+  m_Constraints: 0
+  m_CollisionDetection: 3
+--- !u!114 &7657981801554065792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5406812856881865318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a167ae81725a9c144af7d71a546ad7b6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _fireRate: 0
+  muzzleFlash: {fileID: 386750249455059553}
+  impactEffect: {fileID: 1000010355441670, guid: 02a509a7fa70ed740ba4197e20c5d32d,
+    type: 3}
+  dropEmitter: {fileID: 1577568351210669546}
+  inUse: 0
+  isEquipped: 0
+--- !u!114 &1577568351210669546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5406812856881865318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a6610d2e704f1648819acc8d7460285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CollisionTag: 
+  Event: event:/Johannes/WeaponDrop
+  PlayEvent: 0
+  StopEvent: 0
+  AllowFadeout: 1
+  TriggerOnce: 0
+  Preload: 0
+  Params: []
+  OverrideAttenuation: 0
+  OverrideMinDistance: 1
+  OverrideMaxDistance: 20
 --- !u!1 &5406812856881865320
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/M4_8.prefab
+++ b/Assets/Prefabs/M4_8.prefab
@@ -172,6 +172,7 @@ GameObject:
   - component: {fileID: 2017303569255703696}
   - component: {fileID: 4331897568753730261}
   - component: {fileID: 2716678851220738945}
+  - component: {fileID: 3749711158785976468}
   m_Layer: 11
   m_Name: M4_8
   m_TagString: FireWeapon
@@ -291,8 +292,32 @@ MonoBehaviour:
   muzzleFlash: {fileID: 5365373574556648083}
   impactEffect: {fileID: 1000010844420130, guid: 4edabb1c0dde62743b137378c7d22980,
     type: 3}
+  dropEmitter: {fileID: 3749711158785976468}
   inUse: 0
   isEquipped: 0
+--- !u!114 &3749711158785976468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9191724860870608772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a6610d2e704f1648819acc8d7460285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CollisionTag: 
+  Event: event:/Johannes/WeaponDrop
+  PlayEvent: 0
+  StopEvent: 0
+  AllowFadeout: 1
+  TriggerOnce: 0
+  Preload: 0
+  Params: []
+  OverrideAttenuation: 0
+  OverrideMinDistance: 1
+  OverrideMaxDistance: 20
 --- !u!1 &9191724860870608774
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Uzi.prefab
+++ b/Assets/Prefabs/Uzi.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 8311741328867004610}
   - component: {fileID: 1532602676889507546}
   - component: {fileID: 798373221939579720}
+  - component: {fileID: 840972776713415870}
   m_Layer: 0
   m_Name: Uzi
   m_TagString: Untagged
@@ -132,8 +133,32 @@ MonoBehaviour:
   muzzleFlash: {fileID: 6900961511239499691}
   impactEffect: {fileID: 1000011190285628, guid: beb3acff7ab73944fb8f470f24d74ed3,
     type: 3}
+  dropEmitter: {fileID: 840972776713415870}
   inUse: 0
   isEquipped: 0
+--- !u!114 &840972776713415870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2824039230446170400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9a6610d2e704f1648819acc8d7460285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CollisionTag: 
+  Event: event:/Johannes/WeaponDrop
+  PlayEvent: 0
+  StopEvent: 0
+  AllowFadeout: 1
+  TriggerOnce: 0
+  Preload: 0
+  Params: []
+  OverrideAttenuation: 0
+  OverrideMinDistance: 1
+  OverrideMaxDistance: 20
 --- !u!1 &2824039230446170402
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -678,6 +678,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1478520042}
     m_Modifications:
+    - target: {fileID: 8624699325493113411, guid: 8db53459e0764364094e558d9eb16e4c,
+        type: 3}
+      propertyPath: inUse
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8624699325493113412, guid: 8db53459e0764364094e558d9eb16e4c,
         type: 3}
       propertyPath: m_Name
@@ -2355,6 +2360,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: EnemyContainer (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 3244029778788584321, guid: a1f6c5d2c4f82f3498237044869db328,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3244029778788584350, guid: a1f6c5d2c4f82f3498237044869db328,
         type: 3}
       propertyPath: m_RootOrder
@@ -3041,6 +3051,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: EnemyContainer
+      objectReference: {fileID: 0}
+    - target: {fileID: 3244029778788584321, guid: a1f6c5d2c4f82f3498237044869db328,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3244029778788584350, guid: a1f6c5d2c4f82f3498237044869db328,
         type: 3}
@@ -4179,6 +4194,7 @@ MonoBehaviour:
   player: {fileID: 1848419417}
   weapons: []
   currentWeapon: {fileID: 0}
+  pickEvent: event:/Johannes/WeaponPickUp
 --- !u!1 &1500664749
 GameObject:
   m_ObjectHideFlags: 0
@@ -5101,11 +5117,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1792097115}
     m_Modifications:
-    - target: {fileID: 8624699325493113411, guid: 8db53459e0764364094e558d9eb16e4c,
-        type: 3}
-      propertyPath: inUse
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8624699325493113412, guid: 8db53459e0764364094e558d9eb16e4c,
         type: 3}
       propertyPath: m_Name
@@ -5270,6 +5281,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1792097115}
     m_Modifications:
+    - target: {fileID: 1577568351210669546, guid: 4dffcc8ad44b5c64092f3ca62f97a9ca,
+        type: 3}
+      propertyPath: OverrideAttenuation
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5406812856881708614, guid: 4dffcc8ad44b5c64092f3ca62f97a9ca,
         type: 3}
       propertyPath: m_RootOrder
@@ -5330,9 +5346,7 @@ PrefabInstance:
       propertyPath: m_Name
       value: M1911
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 5320465351508668338, guid: 4dffcc8ad44b5c64092f3ca62f97a9ca, type: 3}
-    - {fileID: 2453873835470347257, guid: 4dffcc8ad44b5c64092f3ca62f97a9ca, type: 3}
+    m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4dffcc8ad44b5c64092f3ca62f97a9ca, type: 3}
 --- !u!1001 &6134133539211260106
 PrefabInstance:

--- a/Assets/Scripts/Player/Controller/WeaponSwitchController.cs
+++ b/Assets/Scripts/Player/Controller/WeaponSwitchController.cs
@@ -1,18 +1,20 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using FMODUnity;
 
 public class WeaponSwitchController : MonoBehaviour
 {
     public int selectedWeapon = 0;
     public Player player;
-    private PlayerShootController _shooter;
-    private Transform _cameraTransform;
     public List<GameObject> weapons = new List<GameObject>();
-    private int maxWeapons = 4;
     public GameObject currentWeapon;
     public static bool slotFull;
+
+    [FMODUnity.EventRef]
+    public string pickEvent;
+
+    private PlayerShootController _shooter;
+    private Transform _cameraTransform;
+    private int maxWeapons = 4;
 
     void Start()
     {
@@ -113,7 +115,8 @@ public class WeaponSwitchController : MonoBehaviour
 
         //Enable script
         coll.gameObject.GetComponent<FireWeapon>().enabled = true;
-        coll.gameObject.GetComponent<FMODUnity.StudioEventEmitter>().Play();
+        //Play pickup sound
+        FMODUnity.RuntimeManager.PlayOneShotAttached(pickEvent, _cameraTransform.gameObject);
     }
 
     void DropWeapon(){

--- a/Assets/Scripts/Player/Controller/WeaponSwitchController.cs
+++ b/Assets/Scripts/Player/Controller/WeaponSwitchController.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using FMODUnity;
 
 public class WeaponSwitchController : MonoBehaviour
 {
@@ -112,6 +113,7 @@ public class WeaponSwitchController : MonoBehaviour
 
         //Enable script
         coll.gameObject.GetComponent<FireWeapon>().enabled = true;
+        coll.gameObject.GetComponent<FMODUnity.StudioEventEmitter>().Play();
     }
 
     void DropWeapon(){
@@ -142,6 +144,8 @@ public class WeaponSwitchController : MonoBehaviour
 
         //Disable script
         currentWeapon.GetComponent<FireWeapon>().enabled = false;
+        //Play the drop sound
+        //_cameraTransform.GetChild(0).GetComponent<FMODUnity.StudioEventEmitter>().Play();
 
         _shooter.setFireWeapon(null);
 

--- a/Assets/Scripts/Weapons/FireWeapon.cs
+++ b/Assets/Scripts/Weapons/FireWeapon.cs
@@ -7,9 +7,14 @@ public abstract class FireWeapon : Weapon
 
     public ParticleSystem muzzleFlash;
     public GameObject impactEffect;
+    public FMODUnity.StudioEventEmitter dropEmitter;
 
     public bool inUse;
     public bool isEquipped;
+    public float dropSoundInterval = 0.5f;
+
+    private float lastPlayTime = 0;
+
     public void reload()
     {
         // Verify if has bullets to reload and wepon is not full
@@ -60,7 +65,7 @@ public abstract class FireWeapon : Weapon
         {
             //if (controller.name == "Player")
             //{
-                muzzleFlash.Play();
+            muzzleFlash.Play();
             //}
 
             //  This should be outside the if statement. But since we only have 1 weapon enemy is decreasing the ammo aswell;
@@ -95,15 +100,27 @@ public abstract class FireWeapon : Weapon
         }
     }
 
-    public bool isInUse(){
+    public bool isInUse()
+    {
         return inUse;
     }
+
     public void setInUse(bool value)
     {
         inUse = value;
     }
 
-    public void SetIsEquipped(bool value){
+    public void SetIsEquipped(bool value)
+    {
         isEquipped = value;
+    }
+
+    void OnCollisionEnter(Collision collision)
+    {
+        if (!dropEmitter.IsPlaying() || Time.time - lastPlayTime >= dropSoundInterval)
+        {
+            lastPlayTime = Time.time;
+            dropEmitter.Play();
+        }
     }
 }

--- a/Assets/Scripts/Weapons/Types/M4A1.cs
+++ b/Assets/Scripts/Weapons/Types/M4A1.cs
@@ -1,7 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 public class M4A1 : FireWeapon {
     public void Awake(){
         _damage = 15;

--- a/Assets/Scripts/Weapons/Types/Pistol.cs
+++ b/Assets/Scripts/Weapons/Types/Pistol.cs
@@ -1,7 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 public class Pistol : FireWeapon {
     public void Awake(){
         _damage = 20;

--- a/Assets/Scripts/Weapons/Types/Uzi.cs
+++ b/Assets/Scripts/Weapons/Types/Uzi.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 public class Uzi : FireWeapon {
     public void Awake(){
         _damage = 10;


### PR DESCRIPTION
When you drop a weapon, it will play an impact sound on collisions. There is an EventEmitter in every weapon with the sound event, but the event is controlled via the FireWeapon script (can be moved to the Weapon if you prefer), and will only avoid playing the sound twice at the same time! It has a small cooldown (for now its 0.5s) so there are no issues when throwing the weapon into a corner.
When you pick a weapon, it will play a quick sound. This one has no EventEmitter and is fully controlled by the WeaponSwitchController through the FMOD RuntimeManager.

To test it out, simply play the game and try to pick some weapons and throw them into the walls/floor.